### PR TITLE
also install processing tools

### DIFF
--- a/damask/Dockerfile
+++ b/damask/Dockerfile
@@ -21,3 +21,4 @@ RUN echo 'alias pip=pip3' >> /root/.bashrc
 RUN ["/bin/bash", "-c", "echo '. /home/DAMASK/env/DAMASK.sh' >> /root/.bashrc"]
 RUN source /home/DAMASK/env/DAMASK.sh
 RUN make spectral
+RUN make processing


### PR DESCRIPTION
now the users have a "full" installation where only commercial software is not included.
Unfortunately, we can not even provide the Intel compiler required for Abaqus/Marc, see https://software.intel.com/en-us/forums/intel-fortran-compiler-for-linux-and-mac-os-x/topic/748925